### PR TITLE
feat(dream): Enhanced Dream Analysis with UI ImprovementsFeature/dream analysis

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,16 +3,24 @@
 import { PreparedTasks } from "@/components/dashboard/PreparedTasks";
 import { AIActivityFeed } from "@/components/dashboard/AIActivityFeed";
 import { QuickLaunch } from "@/components/dashboard/QuickLaunch";
-import { LossAversion } from "@/components/dashboard/LossAversion";
-import { Sparkles, Zap } from "lucide-react";
+import { Sparkles, Zap, Target, ArrowRight } from "lucide-react";
+import { useDream } from "@/contexts/DreamContext";
+import Link from "next/link";
 
 export default function Home() {
+  const { dream, steps } = useDream();
+
   const today = new Date().toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "long",
     day: "numeric",
     weekday: "long",
   });
+
+  // Get active step
+  const activeStep = steps.find(s => s.status === "active");
+  const completedCount = steps.filter(s => s.status === "completed").length;
+  const progressPercent = steps.length > 0 ? Math.round((completedCount / steps.length) * 100) : 0;
 
   return (
     <div className="max-w-6xl">
@@ -40,8 +48,71 @@ export default function Home() {
 
         {/* Right Column: Sidebar Widgets */}
         <div className="space-y-6">
-          {/* Loss Aversion */}
-          <LossAversion hourlyRate={3000} initialIdleMinutes={45} />
+
+          {/* Goal Widget (replaces LossAversion) */}
+          <div className="card">
+            <div className="flex items-center gap-2 mb-4">
+              <Target className="w-5 h-5 text-primary" />
+              <h3 className="font-semibold">目標</h3>
+            </div>
+
+            {dream ? (
+              <>
+                <p className="text-lg font-bold mb-3">{dream}</p>
+                <div className="mb-3">
+                  <div className="flex justify-between text-xs mb-1">
+                    <span className="text-muted-foreground">進捗</span>
+                    <span>{progressPercent}%</span>
+                  </div>
+                  <div className="h-2 bg-muted rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-primary transition-all"
+                      style={{ width: `${progressPercent}%` }}
+                    />
+                  </div>
+                </div>
+                <Link
+                  href="/thinking"
+                  className="text-xs text-primary hover:underline flex items-center gap-1"
+                >
+                  詳細を見る <ArrowRight className="w-3 h-3" />
+                </Link>
+              </>
+            ) : (
+              <>
+                <p className="text-muted-foreground text-sm mb-3">まだ目標が設定されていません</p>
+                <Link
+                  href="/thinking"
+                  className="text-xs text-primary hover:underline flex items-center gap-1"
+                >
+                  目標を設定する <ArrowRight className="w-3 h-3" />
+                </Link>
+              </>
+            )}
+          </div>
+
+          {/* Next Action Widget */}
+          {activeStep && (
+            <div className="card bg-gradient-to-br from-accent/10 to-accent/5 border-accent/20">
+              <div className="flex items-center gap-2 mb-4">
+                <Sparkles className="w-5 h-5 text-accent" />
+                <h3 className="font-semibold">今すること</h3>
+              </div>
+
+              <p className="font-medium mb-2">{activeStep.title}</p>
+              {activeStep.description && (
+                <p className="text-xs text-muted-foreground mb-3">{activeStep.description}</p>
+              )}
+              <p className="text-xs text-muted-foreground mb-3">期間: {activeStep.duration}</p>
+
+              <Link
+                href="/thinking"
+                className="inline-flex items-center gap-2 px-3 py-1.5 bg-accent text-white rounded-lg text-sm hover:opacity-90 transition-opacity"
+              >
+                取り組む <ArrowRight className="w-3 h-3" />
+              </Link>
+            </div>
+          )}
 
           {/* Quick Launch */}
           <QuickLaunch />

--- a/app/thinking/page.tsx
+++ b/app/thinking/page.tsx
@@ -1,30 +1,23 @@
 "use client";
 
-import { FlowSynergy } from "@/components/visuals/FlowSynergy";
 import { DreamToSteps } from "@/components/dashboard/DreamToSteps";
-import { Brain } from "lucide-react";
+import { Target } from "lucide-react";
 
 export default function ThinkingPage() {
     return (
-        <div className="max-w-6xl">
+        <div className="max-w-4xl">
             {/* Header */}
             <header className="mb-8">
                 <div className="flex items-center gap-2 mb-2">
-                    <Brain className="w-5 h-5 text-primary" />
-                    <span className="text-sm text-primary font-medium">思考サポート</span>
+                    <Target className="w-5 h-5 text-primary" />
+                    <span className="text-sm text-primary font-medium">目標達成サポート</span>
                 </div>
-                <h1 className="text-3xl font-bold">思考ノード</h1>
-                <p className="text-muted-foreground mt-1">あなたの思考をグラフ化し、目標を分解します</p>
+                <h1 className="text-3xl font-bold">夢の計画</h1>
+                <p className="text-muted-foreground mt-1">あなたの夢を具体的なステップに分解します</p>
             </header>
 
-            {/* Content */}
-            <div className="grid gap-6">
-                {/* Flow Synergy */}
-                <FlowSynergy />
-
-                {/* Dream to Steps */}
-                <DreamToSteps />
-            </div>
+            {/* Dream to Steps */}
+            <DreamToSteps />
         </div>
     );
 }

--- a/backend/app/routers/skills.py
+++ b/backend/app/routers/skills.py
@@ -80,32 +80,55 @@ async def analyze_skills(request: SkillAnalysisRequest):
 
 class DreamAnalysisRequest(BaseModel):
     dream: str
+    targetDuration: Optional[str] = None  # 例: "6ヶ月", "1年"
+
+
+class SubTask(BaseModel):
+    week: str
+    task: str
+    freeResource: Optional[str] = None
+    paidResource: Optional[str] = None
 
 
 class DreamStep(BaseModel):
     id: int
     title: str
+    description: str = ""
     duration: str
     status: str = "pending"
+    subTasks: List[SubTask] = []
 
 
 @router.post("/dream/analyze", response_model=List[DreamStep])
 async def analyze_dream(request: DreamAnalysisRequest):
     """
-    Analyze a dream/goal and break it down into actionable steps
+    Analyze a dream/goal and break it down into actionable steps with sub-tasks
     """
     from app.services.gemini_service import get_gemini_service
     
     service = get_gemini_service()
-    steps = await service.analyze_dream(request.dream)
+    steps = await service.analyze_dream(request.dream, request.targetDuration)
     
     # Ensure proper format
-    return [
-        DreamStep(
+    result = []
+    for i, step in enumerate(steps):
+        sub_tasks = [
+            SubTask(
+                week=st.get("week", ""), 
+                task=st.get("task", ""),
+                freeResource=st.get("freeResource"),
+                paidResource=st.get("paidResource")
+            )
+            for st in step.get("subTasks", [])
+        ]
+        
+        result.append(DreamStep(
             id=step.get("id", i + 1),
             title=step.get("title", "ステップ"),
+            description=step.get("description", ""),
             duration=step.get("duration", "未定"),
-            status=step.get("status", "pending")
-        )
-        for i, step in enumerate(steps)
-    ]
+            status=step.get("status", "pending"),
+            subTasks=sub_tasks
+        ))
+    
+    return result

--- a/backend/app/services/gemini_service.py
+++ b/backend/app/services/gemini_service.py
@@ -275,45 +275,94 @@ JSONのみを返し、他の説明文は含めないでください。
     # Dream Analysis
     # ========================================
 
-    async def analyze_dream(self, dream: str) -> list:
+    async def analyze_dream(self, dream: str, target_duration: str = None) -> list:
         """
-        Analyze a dream/goal and break it down into actionable steps
+        Analyze a dream/goal and break it down into actionable steps with sub-tasks
         """
+        duration_context = ""
+        if target_duration:
+            duration_context = f"\n目標達成期間: {target_duration}\nこの期間内に達成できるよう、ステップを調整してください。"
+        
         prompt = f"""
-ユーザーの夢/目標: {dream}
+ユーザーの夢/目標: {dream}{duration_context}
 
 この夢を達成するための具体的なステップを5〜7個に分解してください。
+各ステップには週単位のサブタスクも含め、具体的な学習リソースを推薦してください。
+
 各ステップには以下を含めてください:
 - id: 連番 (1から開始)
 - title: ステップのタイトル（簡潔に）
+- description: ステップの具体的な説明（1-2文）
 - duration: 推定所要期間（例: "1ヶ月", "2週間"）
 - status: "pending" (固定)
+- subTasks: 週単位の具体的なタスクの配列
+  - week: 週の範囲（例: "Week 1-2"）
+  - task: 具体的なタスク内容（何をどこまでやるか明確に）
+  - freeResource: 無料で使えるおすすめサイト/アプリ/教材（名前とURL）
+  - paidResource: (オプション) 有料だがおすすめのリソース（名前と価格帯）
 
 以下のJSON形式で返してください:
 [
-  {{"id": 1, "title": "...", "duration": "...", "status": "pending"}},
+  {{
+    "id": 1,
+    "title": "プログラミング基礎を固める",
+    "description": "変数、関数、制御構文など基本的なプログラミング概念を習得する",
+    "duration": "2ヶ月",
+    "status": "pending",
+    "subTasks": [
+      {{
+        "week": "Week 1-2",
+        "task": "Pythonの変数と型を理解し、簡単な計算プログラムを書く",
+        "freeResource": "Progate Python基礎編 (https://prog-8.com/)",
+        "paidResource": "Udemy Python講座 (約2,000円セール時)"
+      }},
+      {{
+        "week": "Week 3-4",
+        "task": "if文、for文、while文を使った制御構文をマスター",
+        "freeResource": "paiza ラーニング (https://paiza.jp/works)",
+        "paidResource": null
+      }}
+    ]
+  }},
   ...
 ]
 
 重要:
 - 現実的で達成可能なステップにする
+- 各ステップに2-4個のサブタスクを含める
+- サブタスクは「何を」「どこまで」やるか具体的に書く
+- freeResourceは必ず含める（無料のサイト/アプリ/YouTube等）
+- paidResourceは良質なものがある場合のみ（なければnull）
 - 順序は達成すべき順番で並べる
 - 最初のステップは今すぐ始められるものにする
 """
         
         result = await self._generate_json(prompt)
         
-        # Ensure we return a list
+        # Ensure we return a list with proper structure
         if isinstance(result, list):
+            # Ensure each step has subTasks
+            for step in result:
+                if "subTasks" not in step:
+                    step["subTasks"] = []
+                if "description" not in step:
+                    step["description"] = ""
             return result
         elif isinstance(result, dict) and "steps" in result:
             return result["steps"]
         else:
-            # Fallback: create a basic structure
+            # Fallback
             return [
-                {"id": 1, "title": "計画を立てる", "duration": "1週間", "status": "pending"},
-                {"id": 2, "title": "基礎を学ぶ", "duration": "1ヶ月", "status": "pending"},
-                {"id": 3, "title": "実践する", "duration": "2ヶ月", "status": "pending"},
+                {
+                    "id": 1, 
+                    "title": "計画を立てる", 
+                    "description": "目標達成のための具体的な計画を策定する",
+                    "duration": "1週間", 
+                    "status": "pending",
+                    "subTasks": [
+                        {"week": "Week 1", "task": "現状分析と目標設定"}
+                    ]
+                },
             ]
 
 # シングルトンインスタンス

--- a/components/dashboard/DreamToSteps.tsx
+++ b/components/dashboard/DreamToSteps.tsx
@@ -2,83 +2,130 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkles, Target, ChevronRight, Loader2 } from "lucide-react";
-import { visionAPI, DreamStep } from "@/lib/api";
+import { Sparkles, Target, ChevronRight, ChevronDown, Loader2, ExternalLink, DollarSign, Trash2 } from "lucide-react";
+import { useDream } from "@/contexts/DreamContext";
 
-
-
-const MOCK_STEPS: DreamStep[] = [
-    { id: 1, title: "プログラミング基礎を固める", duration: "2ヶ月", status: "completed" },
-    { id: 2, title: "Reactをマスターする", duration: "3ヶ月", status: "active" },
-    { id: 3, title: "バックエンド開発を学ぶ", duration: "2ヶ月", status: "pending" },
-    { id: 4, title: "個人プロジェクトを完成させる", duration: "1ヶ月", status: "pending" },
-    { id: 5, title: "ポートフォリオを作成する", duration: "2週間", status: "pending" },
+const DURATION_OPTIONS = [
+    { value: "1ヶ月", label: "1ヶ月" },
+    { value: "3ヶ月", label: "3ヶ月" },
+    { value: "6ヶ月", label: "6ヶ月" },
+    { value: "1年", label: "1年" },
+    { value: "2年", label: "2年" },
 ];
 
 export function DreamToSteps() {
-    const [dream, setDream] = useState("フルスタックエンジニアになる");
-    const [isAnalyzing, setIsAnalyzing] = useState(false);
-    const [steps, setSteps] = useState<DreamStep[]>(MOCK_STEPS);
-    const [showSteps, setShowSteps] = useState(true);
+    const {
+        dream,
+        setDream,
+        targetDuration,
+        setTargetDuration,
+        steps,
+        isAnalyzing,
+        analyzeDream,
+        updateStepStatus,
+        clearDream
+    } = useDream();
+
+    const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
+
+    const toggleStep = (stepId: number) => {
+        setExpandedSteps(prev => {
+            const newSet = new Set(prev);
+            if (newSet.has(stepId)) {
+                newSet.delete(stepId);
+            } else {
+                newSet.add(stepId);
+            }
+            return newSet;
+        });
+    };
 
     const handleAnalyze = async () => {
-        setIsAnalyzing(true);
-        setShowSteps(false);
+        if (!dream.trim()) return;
+        setExpandedSteps(new Set());
+        await analyzeDream();
+        // Auto-expand first step after analysis
+        if (steps.length > 0) {
+            setExpandedSteps(new Set([steps[0].id]));
+        }
+    };
 
-        try {
-            const result = await visionAPI.analyzeDream(dream);
-            setSteps(result);
-            setShowSteps(true);
-        } catch (e) {
-            console.error(e);
-        } finally {
-            setIsAnalyzing(false);
+    const handleStepComplete = (stepId: number) => {
+        updateStepStatus(stepId, "completed");
+        // Activate next pending step
+        const currentIndex = steps.findIndex(s => s.id === stepId);
+        if (currentIndex < steps.length - 1) {
+            updateStepStatus(steps[currentIndex + 1].id, "active");
         }
     };
 
     return (
         <div className="card">
             {/* Header */}
-            <div className="flex items-center gap-2 mb-6">
-                <Target className="w-5 h-5 text-primary" />
-                <h3 className="font-semibold">Dream → Steps</h3>
-                <span className="text-xs text-muted-foreground">夢から逆算</span>
+            <div className="flex items-center justify-between mb-6">
+                <div className="flex items-center gap-2">
+                    <Target className="w-5 h-5 text-primary" />
+                    <h3 className="font-semibold">Dream → Steps</h3>
+                    <span className="text-xs text-muted-foreground">夢から逆算</span>
+                </div>
+                {steps.length > 0 && (
+                    <button
+                        onClick={clearDream}
+                        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-destructive transition-colors"
+                        title="夢をクリア"
+                    >
+                        <Trash2 className="w-3.5 h-3.5" />
+                        クリア
+                    </button>
+                )}
             </div>
 
             {/* Dream Input */}
-            <div className="mb-6">
+            <div className="mb-4">
                 <label className="text-sm text-muted-foreground mb-2 block">あなたの夢・目標</label>
-                <div className="flex gap-2">
-                    <input
-                        type="text"
-                        value={dream}
-                        onChange={(e) => setDream(e.target.value)}
-                        placeholder="例: 世界で活躍するエンジニアになる"
-                        className="flex-1 px-4 py-2.5 bg-muted border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-                    />
-                    <button
-                        onClick={handleAnalyze}
-                        disabled={isAnalyzing}
-                        className="px-4 py-2.5 bg-primary text-primary-foreground rounded-lg font-medium hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center gap-2"
-                    >
-                        {isAnalyzing ? (
-                            <>
-                                <Loader2 className="w-4 h-4 animate-spin" />
-                                分析中
-                            </>
-                        ) : (
-                            <>
-                                <Sparkles className="w-4 h-4" />
-                                分解
-                            </>
-                        )}
-                    </button>
-                </div>
+                <input
+                    type="text"
+                    value={dream}
+                    onChange={(e) => setDream(e.target.value)}
+                    placeholder="例: フルスタックエンジニアになる"
+                    className="w-full px-4 py-2.5 bg-muted border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
             </div>
 
-            {/* Steps Timeline */}
+            {/* Duration Selector */}
+            <div className="mb-6 flex items-center gap-4">
+                <label className="text-sm text-muted-foreground">達成目標期間:</label>
+                <select
+                    value={targetDuration}
+                    onChange={(e) => setTargetDuration(e.target.value)}
+                    className="px-3 py-2 bg-muted border border-border rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                    {DURATION_OPTIONS.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                </select>
+                <button
+                    onClick={handleAnalyze}
+                    disabled={isAnalyzing || !dream.trim()}
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg font-medium hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center gap-2"
+                >
+                    {isAnalyzing ? (
+                        <>
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            分析中
+                        </>
+                    ) : (
+                        <>
+                            <Sparkles className="w-4 h-4" />
+                            分解
+                        </>
+                    )}
+                </button>
+            </div>
+
+            {/* Steps Timeline with Accordion */}
             <AnimatePresence mode="wait">
-                {showSteps && (
+                {steps.length > 0 && (
                     <motion.div
                         initial={{ opacity: 0, y: 20 }}
                         animate={{ opacity: 1, y: 0 }}
@@ -89,48 +136,124 @@ export function DreamToSteps() {
                         <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
 
                         {/* Steps */}
-                        <div className="space-y-4">
-                            {steps.map((step, index) => (
-                                <motion.div
-                                    key={step.id}
-                                    initial={{ opacity: 0, x: -20 }}
-                                    animate={{ opacity: 1, x: 0 }}
-                                    transition={{ delay: index * 0.1 }}
-                                    className="flex items-start gap-4 relative"
-                                >
-                                    {/* Timeline Dot */}
-                                    <div
-                                        className={`
-                      w-8 h-8 rounded-full flex items-center justify-center z-10 shrink-0
-                      ${step.status === "completed" ? "bg-accent text-white" :
-                                                step.status === "active" ? "bg-primary text-white animate-pulse" :
-                                                    "bg-muted text-muted-foreground"}
-                    `}
-                                    >
-                                        {step.status === "completed" ? "✓" : index + 1}
-                                    </div>
+                        <div className="space-y-3">
+                            {steps.map((step, index) => {
+                                const isExpanded = expandedSteps.has(step.id);
+                                const hasSubTasks = step.subTasks && step.subTasks.length > 0;
 
-                                    {/* Content */}
-                                    <div className={`flex-1 p-3 rounded-lg ${step.status === "active" ? "bg-primary/10 border border-primary/20" : "bg-muted/50"}`}>
-                                        <div className="flex items-center justify-between">
-                                            <p className={`font-medium ${step.status === "pending" ? "text-muted-foreground" : ""}`}>
-                                                {step.title}
-                                            </p>
-                                            <span className="text-xs text-muted-foreground">{step.duration}</span>
+                                return (
+                                    <motion.div
+                                        key={step.id}
+                                        initial={{ opacity: 0, x: -20 }}
+                                        animate={{ opacity: 1, x: 0 }}
+                                        transition={{ delay: index * 0.1 }}
+                                        className="relative"
+                                    >
+                                        {/* Main Step Row */}
+                                        <div
+                                            className={`flex items-start gap-4 cursor-pointer`}
+                                            onClick={() => hasSubTasks && toggleStep(step.id)}
+                                        >
+                                            {/* Timeline Dot */}
+                                            <div
+                                                className={`
+                                                    w-8 h-8 rounded-full flex items-center justify-center z-10 shrink-0 cursor-pointer
+                                                    ${step.status === "completed" ? "bg-accent text-white" :
+                                                        step.status === "active" ? "bg-primary text-white animate-pulse" :
+                                                            "bg-muted text-muted-foreground"}
+                                                `}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    if (step.status !== "completed") {
+                                                        handleStepComplete(step.id);
+                                                    }
+                                                }}
+                                                title={step.status === "completed" ? "完了済み" : "クリックで完了"}
+                                            >
+                                                {step.status === "completed" ? "✓" : index + 1}
+                                            </div>
+
+                                            {/* Content */}
+                                            <div className={`flex-1 p-3 rounded-lg ${step.status === "active" ? "bg-primary/10 border border-primary/20" : step.status === "completed" ? "bg-accent/10 border border-accent/20" : "bg-muted/50"}`}>
+                                                <div className="flex items-center justify-between">
+                                                    <div className="flex items-center gap-2">
+                                                        {hasSubTasks && (
+                                                            isExpanded ?
+                                                                <ChevronDown className="w-4 h-4 text-muted-foreground" /> :
+                                                                <ChevronRight className="w-4 h-4 text-muted-foreground" />
+                                                        )}
+                                                        <p className={`font-medium ${step.status === "pending" ? "text-muted-foreground" : step.status === "completed" ? "line-through text-muted-foreground" : ""}`}>
+                                                            {step.title}
+                                                        </p>
+                                                    </div>
+                                                    <span className="text-xs text-muted-foreground">{step.duration}</span>
+                                                </div>
+                                                {step.description && (
+                                                    <p className="text-xs text-muted-foreground mt-1 ml-6">
+                                                        {step.description}
+                                                    </p>
+                                                )}
+                                            </div>
                                         </div>
-                                        {step.status === "active" && (
-                                            <p className="text-xs text-primary mt-1 flex items-center gap-1">
-                                                <ChevronRight className="w-3 h-3" />
-                                                現在進行中
-                                            </p>
-                                        )}
-                                    </div>
-                                </motion.div>
-                            ))}
+
+                                        {/* Expanded Sub-tasks */}
+                                        <AnimatePresence>
+                                            {isExpanded && hasSubTasks && (
+                                                <motion.div
+                                                    initial={{ opacity: 0, height: 0 }}
+                                                    animate={{ opacity: 1, height: "auto" }}
+                                                    exit={{ opacity: 0, height: 0 }}
+                                                    className="ml-12 mt-2 space-y-2"
+                                                >
+                                                    {step.subTasks!.map((subTask, subIndex) => (
+                                                        <div
+                                                            key={subIndex}
+                                                            className="p-3 bg-background border border-border rounded-lg"
+                                                        >
+                                                            <div className="flex items-start gap-2 mb-2">
+                                                                <span className="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">
+                                                                    {subTask.week}
+                                                                </span>
+                                                                <p className="text-sm flex-1">{subTask.task}</p>
+                                                            </div>
+
+                                                            {/* Resources */}
+                                                            <div className="space-y-1 ml-1">
+                                                                {subTask.freeResource && (
+                                                                    <div className="flex items-center gap-2 text-xs text-accent">
+                                                                        <ExternalLink className="w-3 h-3" />
+                                                                        <span className="font-medium">無料:</span>
+                                                                        <span>{subTask.freeResource}</span>
+                                                                    </div>
+                                                                )}
+                                                                {subTask.paidResource && (
+                                                                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                                                        <DollarSign className="w-3 h-3" />
+                                                                        <span className="font-medium">有料:</span>
+                                                                        <span>{subTask.paidResource}</span>
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                                </motion.div>
+                                            )}
+                                        </AnimatePresence>
+                                    </motion.div>
+                                );
+                            })}
                         </div>
                     </motion.div>
                 )}
             </AnimatePresence>
+
+            {/* Empty State */}
+            {steps.length === 0 && !isAnalyzing && (
+                <div className="text-center py-8 text-muted-foreground">
+                    <Target className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                    <p>夢を入力して「分解」をクリック</p>
+                </div>
+            )}
         </div>
     );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -27,7 +27,7 @@ const NAV_ITEMS = [
     { label: "ダッシュボード", href: "/", icon: Home },
     { label: "統計", href: "/stats", icon: BarChart3 },
     { label: "カレンダー", href: "/calendar", icon: Calendar },
-    { label: "思考ノード", href: "/thinking", icon: Brain },
+    { label: "夢の計画", href: "/thinking", icon: Brain },
     { label: "コンテキスト", href: "/resume", icon: History },
     { label: "スキル", href: "/skills", icon: Trophy },
     { label: "チャット", href: "/chat", icon: MessageCircle },

--- a/components/providers/ClientProviders.tsx
+++ b/components/providers/ClientProviders.tsx
@@ -10,6 +10,7 @@ import { LocaleProvider } from "@/components/providers/LocaleProvider";
 import { KeyboardNavProvider } from "@/components/providers/KeyboardNavProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { AuthProvider } from "@/components/providers/AuthProvider";
+import { DreamProvider } from "@/contexts/DreamContext";
 
 // Pages without sidebar
 const NO_SIDEBAR_PATHS = ["/login", "/signup"];
@@ -24,19 +25,21 @@ export function ClientProviders({ children }: { children: ReactNode }) {
                 <LocaleProvider>
                     <ToastProvider>
                         <AuthProvider>
-                            <KeyboardNavProvider>
-                                {showSidebar ? (
-                                    <div className="flex min-h-screen">
-                                        <Sidebar />
-                                        <main className="flex-1 lg:ml-[260px] p-4 lg:p-8 pt-16 lg:pt-8">
-                                            {children}
-                                        </main>
-                                        <CommandPalette />
-                                    </div>
-                                ) : (
-                                    children
-                                )}
-                            </KeyboardNavProvider>
+                            <DreamProvider>
+                                <KeyboardNavProvider>
+                                    {showSidebar ? (
+                                        <div className="flex min-h-screen">
+                                            <Sidebar />
+                                            <main className="flex-1 lg:ml-[260px] p-4 lg:p-8 pt-16 lg:pt-8">
+                                                {children}
+                                            </main>
+                                            <CommandPalette />
+                                        </div>
+                                    ) : (
+                                        children
+                                    )}
+                                </KeyboardNavProvider>
+                            </DreamProvider>
                         </AuthProvider>
                     </ToastProvider>
                 </LocaleProvider>

--- a/components/ui/CommandPalette.tsx
+++ b/components/ui/CommandPalette.tsx
@@ -14,7 +14,7 @@ interface SearchResult {
 
 const SEARCH_RESULTS: SearchResult[] = [
     { type: "page", title: "ダッシュボード", href: "/" },
-    { type: "page", title: "思考ノード", href: "/thinking" },
+    { type: "page", title: "夢の計画", href: "/thinking" },
     { type: "page", title: "スキルツリー", href: "/skills" },
     { type: "page", title: "コンテキスト", href: "/resume" },
     { type: "page", title: "設定", href: "/settings" },

--- a/components/visuals/FlowSynergy.tsx
+++ b/components/visuals/FlowSynergy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import ReactFlow, {
     Background,
     Controls,
@@ -14,143 +14,253 @@ import ReactFlow, {
     MarkerType,
 } from "reactflow";
 import "reactflow/dist/style.css";
-import { Brain, Sparkles } from "lucide-react";
+import { Brain, Sparkles, Loader2 } from "lucide-react";
+import { DreamStep } from "@/lib/api";
+import { useDream } from "@/contexts/DreamContext";
 
-const initialNodes: Node[] = [
-    {
-        id: "dream",
-        type: "input",
-        position: { x: 250, y: 0 },
-        data: { label: "🎯 目標: フルスタックエンジニア" },
-        style: {
-            background: "linear-gradient(135deg, #3ea8ff, #60c5ff)",
-            border: "none",
-            color: "#fff",
-            fontWeight: "bold",
-            padding: "16px 24px",
-            borderRadius: "12px",
-            fontSize: "14px",
-            boxShadow: "0 10px 30px rgba(62, 168, 255, 0.3)",
-        },
-    },
-    {
-        id: "frontend",
-        position: { x: 100, y: 120 },
-        data: { label: "Frontend\n(React/Next.js)" },
-        style: {
-            background: "#1e293b",
-            border: "1px solid #334155",
-            color: "#f8fafc",
-            padding: "12px 20px",
-            borderRadius: "8px",
-            fontSize: "12px",
-            whiteSpace: "pre-wrap",
-            textAlign: "center",
-        },
-    },
-    {
-        id: "backend",
-        position: { x: 400, y: 120 },
-        data: { label: "Backend\n(Python/FastAPI)" },
-        style: {
-            background: "#1e293b",
-            border: "1px solid #334155",
-            color: "#f8fafc",
-            padding: "12px 20px",
-            borderRadius: "8px",
-            fontSize: "12px",
-            whiteSpace: "pre-wrap",
-            textAlign: "center",
-        },
-    },
-    {
-        id: "task1",
-        position: { x: 0, y: 240 },
-        data: { label: "📚 React Query 学習" },
-        style: {
-            background: "#22c55e20",
-            border: "1px solid #22c55e",
-            color: "#22c55e",
-            padding: "10px 16px",
-            borderRadius: "8px",
-            fontSize: "11px",
-        },
-    },
-    {
-        id: "task2",
-        position: { x: 150, y: 240 },
-        data: { label: "🔧 API連携実装" },
-        style: {
-            background: "#f59e0b20",
-            border: "1px solid #f59e0b",
-            color: "#f59e0b",
-            padding: "10px 16px",
-            borderRadius: "8px",
-            fontSize: "11px",
-        },
-    },
-    {
-        id: "task3",
-        position: { x: 320, y: 240 },
-        data: { label: "🐍 FastAPI入門" },
-        style: {
-            background: "#8b5cf620",
-            border: "1px solid #8b5cf6",
-            color: "#8b5cf6",
-            padding: "10px 16px",
-            borderRadius: "8px",
-            fontSize: "11px",
-        },
-    },
-    {
-        id: "task4",
-        position: { x: 470, y: 240 },
-        data: { label: "🗄️ DB設計" },
-        style: {
-            background: "#ec489920",
-            border: "1px solid #ec4899",
-            color: "#ec4899",
-            padding: "10px 16px",
-            borderRadius: "8px",
-            fontSize: "11px",
-        },
-    },
-    {
-        id: "today",
-        type: "output",
-        position: { x: 200, y: 360 },
-        data: { label: "✨ 今日やること: React Query 学習 (30分)" },
-        style: {
-            background: "linear-gradient(135deg, #22c55e, #10b981)",
-            border: "none",
-            color: "#fff",
-            fontWeight: "bold",
-            padding: "12px 20px",
-            borderRadius: "8px",
-            fontSize: "12px",
-            boxShadow: "0 10px 30px rgba(34, 197, 94, 0.3)",
-        },
-    },
+// Color palette for steps
+const STEP_COLORS = [
+    { bg: "#22c55e20", border: "#22c55e", text: "#22c55e" },
+    { bg: "#f59e0b20", border: "#f59e0b", text: "#f59e0b" },
+    { bg: "#8b5cf620", border: "#8b5cf6", text: "#8b5cf6" },
+    { bg: "#ec489920", border: "#ec4899", text: "#ec4899" },
+    { bg: "#3ea8ff20", border: "#3ea8ff", text: "#3ea8ff" },
+    { bg: "#14b8a620", border: "#14b8a6", text: "#14b8a6" },
+    { bg: "#f4364420", border: "#f43644", text: "#f43644" },
 ];
 
-const initialEdges: Edge[] = [
-    { id: "e-dream-frontend", source: "dream", target: "frontend", animated: true, style: { stroke: "#3ea8ff" } },
-    { id: "e-dream-backend", source: "dream", target: "backend", animated: true, style: { stroke: "#3ea8ff" } },
-    { id: "e-frontend-task1", source: "frontend", target: "task1", style: { stroke: "#334155" }, markerEnd: { type: MarkerType.ArrowClosed, color: "#334155" } },
-    { id: "e-frontend-task2", source: "frontend", target: "task2", style: { stroke: "#334155" }, markerEnd: { type: MarkerType.ArrowClosed, color: "#334155" } },
-    { id: "e-backend-task3", source: "backend", target: "task3", style: { stroke: "#334155" }, markerEnd: { type: MarkerType.ArrowClosed, color: "#334155" } },
-    { id: "e-backend-task4", source: "backend", target: "task4", style: { stroke: "#334155" }, markerEnd: { type: MarkerType.ArrowClosed, color: "#334155" } },
-    { id: "e-task1-today", source: "task1", target: "today", animated: true, style: { stroke: "#22c55e" } },
+const DURATION_OPTIONS = [
+    { value: "1ヶ月", label: "1ヶ月" },
+    { value: "3ヶ月", label: "3ヶ月" },
+    { value: "6ヶ月", label: "6ヶ月" },
+    { value: "1年", label: "1年" },
+    { value: "2年", label: "2年" },
 ];
 
-export function FlowSynergy() {
-    const [nodes, , onNodesChange] = useNodesState(initialNodes);
-    const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+interface FlowSynergyProps {
+    showInput?: boolean;
+}
+
+export function FlowSynergy({ showInput = true }: FlowSynergyProps) {
+    const {
+        dream,
+        setDream,
+        targetDuration,
+        setTargetDuration,
+        steps,
+        isAnalyzing,
+        analyzeDream,
+        updateStepStatus
+    } = useDream();
+
+    const [selectedStep, setSelectedStep] = useState<DreamStep | null>(null);
+
+    // Generate nodes and edges from steps
+    const { generatedNodes, generatedEdges } = useMemo(() => {
+        if (!dream && steps.length === 0) {
+            return { generatedNodes: [], generatedEdges: [] };
+        }
+
+        const nodes: Node[] = [];
+        const edges: Edge[] = [];
+
+        // Dream/Goal node at top
+        if (dream) {
+            nodes.push({
+                id: "dream",
+                type: "input",
+                position: { x: 300, y: 0 },
+                data: { label: `🎯 ${dream}` },
+                style: {
+                    background: "linear-gradient(135deg, #3ea8ff, #60c5ff)",
+                    border: "none",
+                    color: "#fff",
+                    fontWeight: "bold",
+                    padding: "16px 24px",
+                    borderRadius: "12px",
+                    fontSize: "14px",
+                    boxShadow: "0 10px 30px rgba(62, 168, 255, 0.3)",
+                    maxWidth: "300px",
+                    textAlign: "center",
+                },
+            });
+        }
+
+        // Step nodes
+        const stepSpacing = 180;
+        const startX = Math.max(0, 300 - ((steps.length - 1) * stepSpacing) / 2);
+
+        steps.forEach((step, index) => {
+            const color = STEP_COLORS[index % STEP_COLORS.length];
+            const x = startX + index * stepSpacing;
+            const y = 120;
+
+            // Adjust color based on status
+            const statusColor = step.status === "completed"
+                ? { bg: "#22c55e30", border: "#22c55e", text: "#22c55e" }
+                : step.status === "active"
+                    ? { bg: "#3ea8ff30", border: "#3ea8ff", text: "#3ea8ff" }
+                    : color;
+
+            nodes.push({
+                id: `step-${step.id}`,
+                position: { x, y },
+                data: {
+                    label: `${step.status === "completed" ? "✓ " : ""}${index + 1}. ${step.title}`,
+                    step: step,
+                },
+                style: {
+                    background: statusColor.bg,
+                    border: `2px solid ${statusColor.border}`,
+                    color: statusColor.text,
+                    padding: "12px 16px",
+                    borderRadius: "8px",
+                    fontSize: "11px",
+                    fontWeight: "500",
+                    cursor: "pointer",
+                    maxWidth: "160px",
+                    textAlign: "center",
+                },
+            });
+
+            // Edge from dream to step
+            if (dream) {
+                const isActive = step.status === "active";
+                const isCompleted = step.status === "completed";
+                edges.push({
+                    id: `e-dream-step-${step.id}`,
+                    source: "dream",
+                    target: `step-${step.id}`,
+                    animated: isActive,
+                    style: {
+                        stroke: isCompleted ? "#22c55e" : isActive ? "#3ea8ff" : "#334155",
+                        strokeWidth: isActive ? 2 : 1,
+                    },
+                    markerEnd: {
+                        type: MarkerType.ArrowClosed,
+                        color: isCompleted ? "#22c55e" : isActive ? "#3ea8ff" : "#334155"
+                    },
+                });
+            }
+
+            // Sub-task nodes (only for first 2 steps to avoid clutter)
+            if (step.subTasks && step.subTasks.length > 0 && index < 2) {
+                const subTaskY = y + 100;
+                step.subTasks.slice(0, 3).forEach((subTask, subIndex) => {
+                    const subX = x - 60 + subIndex * 80;
+                    const subId = `subtask-${step.id}-${subIndex}`;
+
+                    nodes.push({
+                        id: subId,
+                        position: { x: subX, y: subTaskY + subIndex * 30 },
+                        data: { label: subTask.week },
+                        style: {
+                            background: "#1e293b",
+                            border: "1px solid #334155",
+                            color: "#94a3b8",
+                            padding: "6px 10px",
+                            borderRadius: "6px",
+                            fontSize: "9px",
+                        },
+                    });
+
+                    edges.push({
+                        id: `e-step-${step.id}-subtask-${subIndex}`,
+                        source: `step-${step.id}`,
+                        target: subId,
+                        style: { stroke: "#334155", strokeDasharray: "4 2" },
+                    });
+                });
+            }
+        });
+
+        // "Today" node - first active step
+        const activeStep = steps.find(s => s.status === "active");
+        if (activeStep) {
+            const todayY = steps.some(s => s.subTasks && s.subTasks.length > 0) ? 350 : 250;
+            nodes.push({
+                id: "today",
+                type: "output",
+                position: { x: 250, y: todayY },
+                data: { label: `✨ 次にやること: ${activeStep.title}` },
+                style: {
+                    background: "linear-gradient(135deg, #22c55e, #10b981)",
+                    border: "none",
+                    color: "#fff",
+                    fontWeight: "bold",
+                    padding: "12px 20px",
+                    borderRadius: "8px",
+                    fontSize: "12px",
+                    boxShadow: "0 10px 30px rgba(34, 197, 94, 0.3)",
+                    maxWidth: "280px",
+                    textAlign: "center",
+                },
+            });
+
+            edges.push({
+                id: "e-step-today",
+                source: `step-${activeStep.id}`,
+                target: "today",
+                animated: true,
+                style: { stroke: "#22c55e" },
+            });
+        }
+
+        // Progress indicator
+        const completedCount = steps.filter(s => s.status === "completed").length;
+        if (steps.length > 0) {
+            nodes.push({
+                id: "progress",
+                position: { x: 550, y: 0 },
+                data: { label: `📊 ${completedCount}/${steps.length} 完了` },
+                style: {
+                    background: "#1e293b",
+                    border: "1px solid #334155",
+                    color: "#94a3b8",
+                    padding: "8px 12px",
+                    borderRadius: "8px",
+                    fontSize: "11px",
+                },
+            });
+        }
+
+        return { generatedNodes: nodes, generatedEdges: edges };
+    }, [dream, steps]);
+
+    const [nodes, setNodes, onNodesChange] = useNodesState(generatedNodes);
+    const [edges, setEdges, onEdgesChange] = useEdgesState(generatedEdges);
+
+    // Update nodes/edges when data changes
+    useEffect(() => {
+        setNodes(generatedNodes);
+        setEdges(generatedEdges);
+    }, [generatedNodes, generatedEdges, setNodes, setEdges]);
 
     const onConnect = useCallback(
         (params: Connection) => setEdges((eds) => addEdge(params, eds)),
         [setEdges]
     );
+
+    const handleAnalyze = async () => {
+        if (!dream.trim()) return;
+        await analyzeDream();
+    };
+
+    const onNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
+        if (node.data?.step) {
+            setSelectedStep(node.data.step);
+        }
+    }, []);
+
+    const handleStepComplete = (stepId: number) => {
+        updateStepStatus(stepId, "completed");
+        // Activate next pending step
+        const currentIndex = steps.findIndex(s => s.id === stepId);
+        if (currentIndex < steps.length - 1) {
+            updateStepStatus(steps[currentIndex + 1].id, "active");
+        }
+        setSelectedStep(null);
+    };
 
     return (
         <div className="card h-[500px] relative">
@@ -161,11 +271,35 @@ export function FlowSynergy() {
                 <span className="text-xs text-muted-foreground">思考の可視化</span>
             </div>
 
-            {/* AI Suggestion */}
-            <div className="absolute top-4 right-4 z-10 flex items-center gap-2 px-3 py-1.5 bg-accent/10 border border-accent/20 rounded-full">
-                <Sparkles className="w-3 h-3 text-accent" />
-                <span className="text-xs text-accent font-medium">AIが最短ルートを提案中</span>
-            </div>
+            {/* Input (if enabled) */}
+            {showInput && (
+                <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+                    <input
+                        type="text"
+                        value={dream}
+                        onChange={(e) => setDream(e.target.value)}
+                        placeholder="目標を入力..."
+                        className="px-3 py-1.5 bg-muted border border-border rounded-lg text-sm w-40"
+                    />
+                    <select
+                        value={targetDuration}
+                        onChange={(e) => setTargetDuration(e.target.value)}
+                        className="px-2 py-1.5 bg-muted border border-border rounded-lg text-sm"
+                    >
+                        {DURATION_OPTIONS.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                    </select>
+                    <button
+                        onClick={handleAnalyze}
+                        disabled={isAnalyzing || !dream.trim()}
+                        className="px-3 py-1.5 bg-primary text-white rounded-lg text-sm flex items-center gap-1 disabled:opacity-50"
+                    >
+                        {isAnalyzing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
+                        分析
+                    </button>
+                </div>
+            )}
 
             {/* React Flow Canvas */}
             <ReactFlow
@@ -174,6 +308,7 @@ export function FlowSynergy() {
                 onNodesChange={onNodesChange}
                 onEdgesChange={onEdgesChange}
                 onConnect={onConnect}
+                onNodeClick={onNodeClick}
                 fitView
                 proOptions={{ hideAttribution: true }}
                 className="rounded-xl"
@@ -186,6 +321,54 @@ export function FlowSynergy() {
                     className="!bg-card !border-border !rounded-lg"
                 />
             </ReactFlow>
+
+            {/* Selected Step Detail */}
+            {selectedStep && (
+                <div className="absolute bottom-4 left-4 right-4 z-10 p-4 bg-card/95 backdrop-blur border border-border rounded-lg">
+                    <div className="flex justify-between items-start mb-2">
+                        <h4 className="font-semibold text-sm">{selectedStep.title}</h4>
+                        <div className="flex items-center gap-2">
+                            {selectedStep.status !== "completed" && (
+                                <button
+                                    onClick={() => handleStepComplete(selectedStep.id)}
+                                    className="text-xs px-2 py-1 bg-accent text-white rounded hover:opacity-90"
+                                >
+                                    完了にする
+                                </button>
+                            )}
+                            <button
+                                onClick={() => setSelectedStep(null)}
+                                className="text-muted-foreground hover:text-foreground"
+                            >
+                                ✕
+                            </button>
+                        </div>
+                    </div>
+                    {selectedStep.description && (
+                        <p className="text-xs text-muted-foreground mb-2">{selectedStep.description}</p>
+                    )}
+                    {selectedStep.subTasks && selectedStep.subTasks.length > 0 && (
+                        <div className="space-y-1">
+                            {selectedStep.subTasks.slice(0, 3).map((st, i) => (
+                                <div key={i} className="text-xs flex gap-2">
+                                    <span className="text-primary font-medium">{st.week}:</span>
+                                    <span className="text-muted-foreground">{st.task.slice(0, 60)}...</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* Empty state */}
+            {nodes.length === 0 && !isAnalyzing && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="text-center text-muted-foreground">
+                        <Brain className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                        <p>目標を入力して「分析」をクリック</p>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/contexts/DreamContext.tsx
+++ b/contexts/DreamContext.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, useEffect, ReactNode } from "react";
+import { DreamStep, visionAPI } from "@/lib/api";
+
+const STORAGE_KEY = "vision-dream-data";
+
+interface DreamData {
+    dream: string;
+    targetDuration: string;
+    steps: DreamStep[];
+}
+
+interface DreamContextType {
+    // State
+    dream: string;
+    targetDuration: string;
+    steps: DreamStep[];
+    isAnalyzing: boolean;
+    error: string | null;
+
+    // Actions
+    setDream: (dream: string) => void;
+    setTargetDuration: (duration: string) => void;
+    analyzeDream: () => Promise<void>;
+    updateStepStatus: (stepId: number, status: "pending" | "active" | "completed") => void;
+    clearDream: () => void;
+}
+
+const DreamContext = createContext<DreamContextType | undefined>(undefined);
+
+// Helper to safely access localStorage
+const getStoredData = (): DreamData | null => {
+    if (typeof window === "undefined") return null;
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored ? JSON.parse(stored) : null;
+    } catch {
+        return null;
+    }
+};
+
+const saveData = (data: DreamData) => {
+    if (typeof window === "undefined") return;
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+        // Ignore storage errors
+    }
+};
+
+const clearStoredData = () => {
+    if (typeof window === "undefined") return;
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Ignore
+    }
+};
+
+export function DreamProvider({ children }: { children: ReactNode }) {
+    const [dream, setDreamState] = useState("");
+    const [targetDuration, setTargetDurationState] = useState("6ヶ月");
+    const [steps, setSteps] = useState<DreamStep[]>([]);
+    const [isAnalyzing, setIsAnalyzing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [isHydrated, setIsHydrated] = useState(false);
+
+    // Load from localStorage on mount
+    useEffect(() => {
+        const stored = getStoredData();
+        if (stored) {
+            setDreamState(stored.dream || "");
+            setTargetDurationState(stored.targetDuration || "6ヶ月");
+            setSteps(stored.steps || []);
+        }
+        setIsHydrated(true);
+    }, []);
+
+    // Save to localStorage on changes (after hydration)
+    useEffect(() => {
+        if (!isHydrated) return;
+        saveData({ dream, targetDuration, steps });
+    }, [dream, targetDuration, steps, isHydrated]);
+
+    const setDream = useCallback((value: string) => {
+        setDreamState(value);
+    }, []);
+
+    const setTargetDuration = useCallback((value: string) => {
+        setTargetDurationState(value);
+    }, []);
+
+    const analyzeDream = useCallback(async () => {
+        if (!dream.trim()) return;
+
+        setIsAnalyzing(true);
+        setError(null);
+        setSteps([]);
+
+        try {
+            const result = await visionAPI.analyzeDream(dream, targetDuration);
+            // Set first step as active
+            const stepsWithActive = result.map((step, i) => ({
+                ...step,
+                status: i === 0 ? "active" as const : "pending" as const
+            }));
+            setSteps(stepsWithActive);
+        } catch (e) {
+            console.error(e);
+            setError("分析に失敗しました");
+        } finally {
+            setIsAnalyzing(false);
+        }
+    }, [dream, targetDuration]);
+
+    const updateStepStatus = useCallback((stepId: number, status: "pending" | "active" | "completed") => {
+        setSteps(prev => prev.map(step =>
+            step.id === stepId ? { ...step, status } : step
+        ));
+    }, []);
+
+    const clearDream = useCallback(() => {
+        setDreamState("");
+        setSteps([]);
+        setError(null);
+        clearStoredData();
+    }, []);
+
+    return (
+        <DreamContext.Provider value={{
+            dream,
+            targetDuration,
+            steps,
+            isAnalyzing,
+            error,
+            setDream,
+            setTargetDuration,
+            analyzeDream,
+            updateStepStatus,
+            clearDream,
+        }}>
+            {children}
+        </DreamContext.Provider>
+    );
+}
+
+export function useDream() {
+    const context = useContext(DreamContext);
+    if (context === undefined) {
+        throw new Error("useDream must be used within a DreamProvider");
+    }
+    return context;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -38,11 +38,20 @@ export interface SkillNode {
     unlocked: boolean;
 }
 
+export interface SubTask {
+    week: string;
+    task: string;
+    freeResource?: string;
+    paidResource?: string;
+}
+
 export interface DreamStep {
     id: number;
     title: string;
+    description?: string;
     duration: string;
     status: "pending" | "active" | "completed";
+    subTasks?: SubTask[];
 }
 
 // API Client
@@ -168,7 +177,7 @@ class VisionAPIClient {
     }
 
     // Dream to Steps
-    async analyzeDream(dream: string): Promise<DreamStep[]> {
+    async analyzeDream(dream: string, targetDuration?: string): Promise<DreamStep[]> {
         if (useMock('skills')) {
             await new Promise(r => setTimeout(r, 2000));
             return [
@@ -179,7 +188,7 @@ class VisionAPIClient {
         }
         return this.fetch<DreamStep[]>("/api/dream/analyze", {
             method: "POST",
-            body: JSON.stringify({ dream }),
+            body: JSON.stringify({ dream, targetDuration }),
         });
     }
 
@@ -207,8 +216,8 @@ export const API_CONFIG = {
     useReal: {
         tasks: true,    // ✅ Implemented
         stats: false,   // 🚧 Pending
-        skills: false,  // 🚧 Pending
-        chat: true,    // ✅ Implemented
+        skills: true,   // ✅ Implemented (Dream Analysis)
+        chat: true,     // ✅ Implemented
         user: true,     // ✅ Implemented
     }
 };

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -6,7 +6,7 @@ export const translations = {
     ja: {
         // Navigation
         dashboard: "ダッシュボード",
-        thinking: "思考ノード",
+        thinking: "夢の計画",
         context: "コンテキスト",
         skills: "スキル",
         stats: "統計",


### PR DESCRIPTION
概要
夢/目標を具体的なステップに分解する「Dream Analysis」機能を強化しました。

変更内容
🆕 新機能
詳細なサブタスク: 各ステップに週単位のサブタスクを追加（例: Week 1-2: Pythonの変数と型を理解する）
リソース推薦: 無料リソース（Progate, paiza等）と有料オプション（Udemy等）を自動提案
期間指定: 目標達成期間を選択可能（1ヶ月〜2年）
アコーディオンUI: クリックでサブタスクを展開/折りたたみ
共有状態（DreamContext）: ダッシュボードと夢の計画ページでデータを同期
localStorage永続化: リロードしても夢とステップが保持される
🎨 UI改善
ダッシュボード: 「機会損失」を削除、「目標」と「今すること」ウィジェットに置き換え
サイドバー: 「思考ノード」→「夢の計画」に名称変更
夢の計画ページ: FlowSynergy（図解）を削除、DreamToStepsのみに簡素化